### PR TITLE
add working packaging, extend README.md with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # helium-miner-snap
 Alternate software solution
+
+## building
+
+This snap is designed to be built on an arm64 device like a Pi4 using an Ubuntu Core or Classic install.
+
+- install lxd and create a focal (20.04) lxd container
+
+    ```
+    $ sudo snap install lxd
+    $ sudo lxd init --auto
+    $ sudo lxc launch ubuntu:20.04 focal
+    ```
+
+- enter the container and install snapcraft
+
+    ```
+    $ sudo lxc shell focal
+    # snap install snapcraft --classic
+    ```
+
+- clone this branch and build it
+
+    ```
+    # git clone https://github.com/ogra1/hm-miner-snap.git
+    # cd hm-miner-snap
+    # snapcraft --destructive-mode
+    ...
+    Snapped nebra-helium-miner_0.1.0_arm64.snap
+    # exit
+    $
+    ```
+
+- pull the file from the container
+
+    ```
+    $ lxc file pull focal/root/hm-miner-snap/nebra-helium-miner_0.1.0_arm64.snap .
+    $ ls -lh nebra-helium-miner_0.1.0_arm64.snap
+    -rw-r--r-- 1 ogra ogra 56M Feb 18 17:17 nebra-helium-miner_0.1.0_arm64.snap
+    $
+    ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,36 +1,94 @@
-name: nebra-helium-miner # you probably want to 'snapcraft register <name>'
-base: core20 # the base snap is the execution environment for this snap
-version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
-summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+name: nebra-helium-miner
+base: core20
+adopt-info: miner
+summary: Miner for helium blockchain
 description: |
-  This is my-snap's description. You have a paragraph or two to tell the
-  most important story about your snap. Keep it under 100 words though,
-  we live in tweetspace and your description wants to look good in the snap
-  store.
+  Miner for the helium blockchain. Thsi snap requires the i2c and log-observe interfaces
+  to be connected to work properly, run:
 
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+      snap connect helium-miner:i2c pi:i2c-1
+      snap connect helium-miner:log-observe
+
+  after installing the snap.
+  All data, log files etc are stored under /var/snap/helium-miner/common
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: arm64
+    run-on: arm64
+
+apps:
+  miner:
+    command: miner/bin/miner foreground
+    daemon: simple
+    environment:
+      COOKIE: "miner"
+      HOME: "$SNAP_COMMON"
+      PATH: "/usr/lib/erlang/bin:$SNAP/miner/bin:$PATH"
+      RELX_OUT_FILE_PATH: "/tmp"
+    plugs:
+      - i2c
+      - log-observe
+      - network
+      - network-bind
+
+layout:
+  /usr/lib/erlang:
+    bind: $SNAP/usr/lib/erlang
+  /var/log/miner:
+    bind: $SNAP_COMMON/log
 
 parts:
+  erlang:
+    plugin: dump
+    source: https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_22.3.4.2-1~ubuntu~focal_arm64.deb
+    stage-packages:
+      - libtinfo6
   miner:
-    # See 'snapcraft plugins'
+    after: [ erlang ]
+    plugin: make
     source: https://github.com/helium/miner.git
     build-packages:
-      - libdbus-1-dev
       - autoconf
       - automake
-      - libtool
-      - flex
-      - libgmp-dev
+      - bison
+      - cargo
       - cmake
+      - doxygen
+      - flex
+      - g++
+      - libclang-dev
+      - libdbus-1-dev
+      - libgmp-dev
+      - libsnappy-dev
       - libsodium-dev
       - libssl-dev
-      - bison
-      - libsnappy-dev
-      - libclang-dev
-      - doxygen
-      - make
-      - erlang
-      - cargo
-
-    plugin: make
+      - libtool
+    stage-packages:
+      - libsodium23
+    build-environment:
+      - PATH: "${SNAPCRAFT_STAGE}/usr/lib/erlang/bin:$PATH"
+      - CFLAGS: "-U__sun__"
+      - ERLANG_ROCKSDB_OPTS: "-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON"
+      - ERL_COMPILER_OPTIONS: "[deterministic]"
+    override-build: |
+      # use erlang from staging dir
+      ln -sf $SNAPCRAFT_STAGE/usr/lib/erlang /usr/lib/erlang
+      # set package version from miner upstream version
+      VER="$(grep -m1 "{release, {miner," $SNAPCRAFT_PART_SRC/rebar.config | sed 's/^.* "//;s/".*$//')"
+      echo "setting snap version to $VER"
+      snapcraftctl set-version "$VER"
+      # build and install
+      make release && \
+      cp -av $SNAPCRAFT_PART_BUILD/_build/prod/rel/miner $SNAPCRAFT_PART_INSTALL/
+  blockchain-api:
+    after: [ miner ]
+    plugin: nil
+    override-build: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/miner/updates
+      wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis \
+        --output-document=$SNAPCRAFT_PART_INSTALL/miner/updates/genesis
+    build-packages:
+      - wget


### PR DESCRIPTION
This creates the initial build setup, the resulting snap starts (after connecting the interfaces) but it is not clear if it also works on the target hardware.

DBus support still needs to be added and perhaps there is some patching necessary to make the config files editable. This is a good starting point though.