### PR TITLE
Add dbus support, hold back daemon until interfaces are connected, ship a cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # helium-miner-snap
-Alternate software solution
+
+Miner for the helium blockchain. This snap requires multiple interfaces to
+be connected before the miner daemon can start.
+
+    snap connect helium-miner:i2c pi:i2c-1
+    snap connect helium-miner:log-observe
+    snap connect helium-miner:hardware-observe
+    snap connect helium-miner:network-control
+
+After connecting these interfaces the miner daemon will automatically start.
+All variable data and log files are stored under /var/snap/helium-miner/common
+
+To talk directly to the miner daemon you can use the shipped
+nebra-helium-miner command like below.
+
+    sudo nebra-helium-miner info summary
+
+The genesis blockchain api can be found in
+/var/snap/helium-miner/common/miner/update/genesis
+You can use the "sudo nebra-helium-miner load genesis ..." command
+pointing to that directory to load and update the blockchain api.
+
+The miner daemon registers as com.helium.Miner to the system dbus of the host
 
 ## building
 

--- a/snap/hooks/connect-plug-hardware-observe
+++ b/snap/hooks/connect-plug-hardware-observe
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# only start the daemon if all other interfaces are connected too
+for interface in log-observe i2c network-control; do
+  if ! snapctl is-connected $interface; then
+    exit 0
+  fi
+done
+
+if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.daemon 2>&1 || true
+fi

--- a/snap/hooks/connect-plug-i2c
+++ b/snap/hooks/connect-plug-i2c
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# only start the daemon if all other interfaces are connected too
+for interface in log-observe hardware-observe network-control; do
+  if ! snapctl is-connected $interface; then
+    exit 0
+  fi
+done
+
+if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.daemon 2>&1 || true
+fi

--- a/snap/hooks/connect-plug-log-observe
+++ b/snap/hooks/connect-plug-log-observe
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# only start the daemon if all other interfaces are connected too
+for interface in i2c hardware-observe network-control; do
+  if ! snapctl is-connected $interface; then
+    exit 0
+  fi
+done
+
+if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.daemon 2>&1 || true
+fi

--- a/snap/hooks/connect-plug-network-control
+++ b/snap/hooks/connect-plug-network-control
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# only start the daemon if all other interfaces are connected too
+for interface in log-observe hardware-observe i2c; do
+  if ! snapctl is-connected $interface; then
+    exit 0
+  fi
+done
+
+if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.daemon 2>&1 || true
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,62 @@
+#! /bin/sh
+
+# copy default config to writable place if it does not exist yet
+if [ ! -e $SNAP_COMMON/config/sys.config ]; then
+  mkdir -p $SNAP_COMMON/config
+  cp $SNAP/miner/releases/0.1.0/sys.config $SNAP_COMMON/config/
+  # set key to undefined to be able to run without i2c attached key
+  #sed -i 's/{key, .*$/{key, undefined},/' \
+  #  $SNAP_COMMON/config/sys.config
+fi
+
+# copy blockchain-api to writable place if it does not exist yet
+if [ ! -e $SNAP_COMMON/update/genesis ]; then
+  mkdir -p $SNAP_COMMON/update
+  cp $SNAP/miner/update/genesis $SNAP_COMMON/update/genesis
+fi
+
+# put fake lsb_release in place if it is size zero
+if [ "$(stat -c %s $SNAP_COMMON/.lsb_release)" = "0" ]; then
+  cat /etc/os-release >$SNAP_COMMON/.lsb_release
+fi
+
+# only start if all interfaces are connected
+DISABLED=""
+
+disable(){
+  snapctl stop --disable ${SNAP_NAME}.daemon
+}
+
+if ! snapctl is-connected i2c; then
+  logger -t ${SNAP_NAME} "need access to i2c device !!!"
+  logger -t ${SNAP_NAME} "please run snap connect ${SNAP_NAME}:i2c pi:i2c-0"
+  DISABLED="true"
+fi
+
+if ! snapctl is-connected log-observe; then
+  logger -t ${SNAP_NAME} "need read access to logs !!!"
+  logger -t ${SNAP_NAME} "please run snap connect ${SNAP_NAME}:log-observe"
+  DISABLED="true"
+fi
+
+if ! snapctl is-connected hardware-observe; then
+  logger -t ${SNAP_NAME} "need read access to hardware information !!!"
+  logger -t ${SNAP_NAME} "please run snap connect ${SNAP_NAME}:hardware-observe"
+  DISABLED="true"
+fi
+
+if ! snapctl is-connected network-control; then
+  logger -t ${SNAP_NAME} "need access to control the network !!!"
+  logger -t ${SNAP_NAME} "please run snap connect ${SNAP_NAME}:network-control"
+  DISABLED="true"
+fi
+
+if [ -n "$DISABLED" ]; then
+  logger -t ${SNAP_NAME} "necessary interfaces not connected, disabling service for the moment"
+  disable
+  exit 0
+fi
+
+if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.daemon 2>&1 || true
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ base: core20
 adopt-info: miner
 summary: Miner for helium blockchain
 description: |
-  Miner for the helium blockchain. Thsi snap requires multiple interfaces to
+  Miner for the helium blockchain. This snap requires multiple interfaces to
   be connected before the miner daemon can start.
 
       snap connect helium-miner:i2c pi:i2c-1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,14 +3,28 @@ base: core20
 adopt-info: miner
 summary: Miner for helium blockchain
 description: |
-  Miner for the helium blockchain. Thsi snap requires the i2c and log-observe interfaces
-  to be connected to work properly, run:
+  Miner for the helium blockchain. Thsi snap requires multiple interfaces to
+  be connected before the miner daemon can start.
 
       snap connect helium-miner:i2c pi:i2c-1
       snap connect helium-miner:log-observe
+      snap connect helium-miner:hardware-observe
+      snap connect helium-miner:network-control
 
-  after installing the snap.
-  All data, log files etc are stored under /var/snap/helium-miner/common
+  After connecting these interfaces the miner daemon will automatically start.
+  All variable data and log files are stored under /var/snap/helium-miner/common
+
+  To talk directly to the miner daemon you can use the shipped
+  nebra-helium-miner command like below.
+
+      sudo nebra-helium-miner info summary
+
+  The genesis blockchain api can be found in
+  /var/snap/helium-miner/common/miner/update/genesis
+  You can use the "sudo nebra-helium-miner load genesis ..." command
+  pointing to that directory to load and update the blockchain api.
+
+  The miner daemon registers as com.helium.Miner to the system dbus of the host
 
 grade: stable
 confinement: strict
@@ -20,25 +34,59 @@ architectures:
     run-on: arm64
 
 apps:
-  miner:
-    command: miner/bin/miner foreground
-    daemon: simple
+  daemon:
+    command: miner/bin/miner start
+    daemon: forking
     environment:
       COOKIE: "miner"
       HOME: "$SNAP_COMMON"
       PATH: "/usr/lib/erlang/bin:$SNAP/miner/bin:$PATH"
       RELX_OUT_FILE_PATH: "/tmp"
+      RELX_CONFIG_PATH: "$SNAP_COMMON/config/sys"
+      RUNNER_LOG_DIR: "$SNAP_COMMON/log"
     plugs:
       - i2c
       - log-observe
       - network
       - network-bind
+      - network-control
+      - hardware-observe
+    slots:
+      - dbus-svc
+  nebra-helium-miner:
+    command: miner/bin/miner
+    environment:
+      COOKIE: "miner"
+      HOME: "$SNAP_COMMON"
+      PATH: "/usr/lib/erlang/bin:$SNAP/miner/bin:$PATH"
+      RELX_OUT_FILE_PATH: "/tmp"
+      RELX_CONFIG_PATH: "$SNAP_COMMON/config/sys"
+      RUNNER_LOG_DIR: "$SNAP_COMMON/log"
+    plugs:
+      - i2c
+      - log-observe
+      - network
+      - network-bind
+      - network-control
+      - hardware-observe
+
+slots:
+  dbus-svc:
+    interface: dbus
+    bus: system
+    name: com.helium.Miner
 
 layout:
   /usr/lib/erlang:
     bind: $SNAP/usr/lib/erlang
   /var/log/miner:
     bind: $SNAP_COMMON/log
+  /var/data:
+    bind: $SNAP_COMMON/data
+  /opt/miner/update:
+    bind: $SNAP_COMMON/update
+  /etc/lsb_release:
+    bind-file: $SNAP_COMMON/.lsb_release
 
 parts:
   erlang:
@@ -87,8 +135,8 @@ parts:
     after: [ miner ]
     plugin: nil
     override-build: |
-      mkdir -p $SNAPCRAFT_PART_INSTALL/miner/updates
+      mkdir -p $SNAPCRAFT_PART_INSTALL/miner/update
       wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis \
-        --output-document=$SNAPCRAFT_PART_INSTALL/miner/updates/genesis
+        --output-document=$SNAPCRAFT_PART_INSTALL/miner/update/genesis
     build-packages:
       - wget


### PR DESCRIPTION
- make the snap expose as com.helium.Miner on the system dbus
- add network-control and hardware-observe interfaces
- hold back daemon from starting via snap hooks until all interfaces are connected
- ship a "nebra-helium-miner" cli command to interact with the daemon from a login shell
- move genesis blockchain api to RW location (/var/snap/helium-miner/common/miner/update/genesis)
- move configuration to /var/snap/nebra-helium-miner/common/config/
- provide os-release info as /etc/lsb_release info to the daemon (to prevent error in "info summary")
- update description
- update README with runtime instructions
